### PR TITLE
disabled duckdb next build

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -21,14 +21,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  duckdb-next-build:
-    name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
-    with:
-      duckdb_version: main
-      ci_tools_version: main
-      extension_name: flockmtl
-      exclude_archs: 'wasm_mvp;wasm_threads;wasm_eh'
+  #  duckdb-next-build:
+  #    name: Build extension binaries
+  #    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+  #    with:
+  #      duckdb_version: main
+  #      ci_tools_version: main
+  #      extension_name: flockmtl
+  #      exclude_archs: 'wasm_mvp;wasm_threads;wasm_eh'
 
   duckdb-stable-build:
     name: Build extension binaries


### PR DESCRIPTION
Due to changes DuckDB made to extension initialization in the main branch for the upcoming release, we will disable this build until the official release is available.