### PR TITLE
Removed the empty params context columns

### DIFF
--- a/src/functions/batch_response_builder.cpp
+++ b/src/functions/batch_response_builder.cpp
@@ -36,6 +36,12 @@ nlohmann::json CastVectorOfStructsToJson(const duckdb::Vector& struct_vector, co
                         struct_json["context_columns"][context_column_idx]["data"].push_back(context_column_json["data"]);
                     } else {
                         struct_json["context_columns"].push_back(context_column_json);
+                        for (const auto& key: allowed_keys) {
+                            if (key != "data" && (!struct_json["context_columns"][context_column_idx].contains(key) ||
+                                                  struct_json["context_columns"][context_column_idx][key].get<std::string>() == "NULL")) {
+                                struct_json["context_columns"][context_column_idx].erase(key);
+                            }
+                        }
                         struct_json["context_columns"][context_column_idx]["data"] = nlohmann::json::array();
                         struct_json["context_columns"][context_column_idx]["data"].push_back(context_column_json["data"]);
                     }


### PR DESCRIPTION
I'm fixing an issue with the STRUCT parser. The problem is that the parser was adding unnecessary empty parameters into the struct output.

For example, the parser would return something like:

```json
{"data": ["Coffee Maker"], "name": "test", "type": "NULL"}
```

But the expected and correct output should be:

```json
{"data": ["Coffee Maker"], "name": "test"}
```

So the fix ensures that empty or null parameters (like `"type": "NULL"`) are removed, keeping the struct clean and consistent with the intended API behavior.