### PR TITLE
fixed the llm_first and llm_last unit tests to handle multiple columns

### DIFF
--- a/test/unit/functions/aggregate/llm_first.cpp
+++ b/test/unit/functions/aggregate/llm_first.cpp
@@ -8,7 +8,7 @@ protected:
     // The LLM response (for mocking)
     static constexpr const char* LLM_RESPONSE = R"({"items":[0]})";
     // The expected function output (selected data)
-    static constexpr const char* EXPECTED_RESPONSE = R"({"data":["High-performance running shoes with advanced cushioning"]})";
+    static constexpr const char* EXPECTED_RESPONSE = R"([{"data":["High-performance running shoes with advanced cushioning"]}])";
 
     std::string GetExpectedResponse() const override {
         return EXPECTED_RESPONSE;
@@ -85,7 +85,7 @@ TEST_F(LLMFirstTest, LLMFirstWithGroupBy) {
     for (idx_t i = 0; i < results->RowCount(); i++) {
         EXPECT_NO_THROW({
             nlohmann::json parsed = nlohmann::json::parse(results->GetValue(1, i).GetValue<std::string>());
-            EXPECT_TRUE(parsed.contains("data"));
+            EXPECT_TRUE(parsed[0].contains("data"));
         });
     }
 }
@@ -126,7 +126,7 @@ TEST_F(LLMFirstTest, Operation_MultipleInputs_ProcessesCorrectly) {
     for (idx_t i = 0; i < results->RowCount(); i++) {
         EXPECT_NO_THROW({
             nlohmann::json parsed = nlohmann::json::parse(results->GetValue(1, i).GetValue<std::string>());
-            EXPECT_TRUE(parsed.contains("data"));
+            EXPECT_TRUE(parsed[0].contains("data"));
         });
     }
 }
@@ -155,7 +155,7 @@ TEST_F(LLMFirstTest, Operation_LargeInputSet_ProcessesCorrectly) {
     for (idx_t i = 0; i < results->RowCount(); i++) {
         EXPECT_NO_THROW({
             nlohmann::json parsed = nlohmann::json::parse(results->GetValue(1, i).GetValue<std::string>());
-            EXPECT_TRUE(parsed.contains("data"));
+            EXPECT_TRUE(parsed[0].contains("data"));
         });
     }
 }

--- a/test/unit/functions/aggregate/llm_last.cpp
+++ b/test/unit/functions/aggregate/llm_last.cpp
@@ -8,7 +8,7 @@ protected:
     // The LLM response (for mocking) - for llm_last, it should select the last index
     static constexpr const char* LLM_RESPONSE = R"({"items":[0]})";
     // The expected function output (selected data from the last position)
-    static constexpr const char* EXPECTED_RESPONSE = R"({"data":["High-performance running shoes with advanced cushioning"]})";
+    static constexpr const char* EXPECTED_RESPONSE = R"([{"data":["High-performance running shoes with advanced cushioning"]}])";
 
     std::string GetExpectedResponse() const override {
         return EXPECTED_RESPONSE;
@@ -85,7 +85,7 @@ TEST_F(LLMLastTest, LLMLastWithGroupBy) {
     for (idx_t i = 0; i < results->RowCount(); i++) {
         EXPECT_NO_THROW({
             nlohmann::json parsed = nlohmann::json::parse(results->GetValue(1, i).GetValue<std::string>());
-            EXPECT_TRUE(parsed.contains("data"));
+            EXPECT_TRUE(parsed[0].contains("data"));
         });
     }
 }
@@ -126,7 +126,7 @@ TEST_F(LLMLastTest, Operation_MultipleInputs_ProcessesCorrectly) {
     for (idx_t i = 0; i < results->RowCount(); i++) {
         EXPECT_NO_THROW({
             nlohmann::json parsed = nlohmann::json::parse(results->GetValue(1, i).GetValue<std::string>());
-            EXPECT_TRUE(parsed.contains("data"));
+            EXPECT_TRUE(parsed[0].contains("data"));
         });
     }
 }
@@ -155,7 +155,7 @@ TEST_F(LLMLastTest, Operation_LargeInputSet_ProcessesCorrectly) {
     for (idx_t i = 0; i < results->RowCount(); i++) {
         EXPECT_NO_THROW({
             nlohmann::json parsed = nlohmann::json::parse(results->GetValue(1, i).GetValue<std::string>());
-            EXPECT_TRUE(parsed.contains("data"));
+            EXPECT_TRUE(parsed[0].contains("data"));
         });
     }
 }


### PR DESCRIPTION
Updated the llm_first and llm_last unit tests to support multiple columns. The previous expected results were set as an object representing the first element of the list, rather than a list itself.